### PR TITLE
Adding Reasoning LLMs are Wandering Solution Explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,10 @@
 
    *Huang, Kaixuan and Guo, Jiacheng and Li, Zihao and Ji, Xiang and Ge, Jiawei and Li, Wenzhe and Guo, Yingqing and Cai, Tianle and Yuan, Hui and Wang, Runzhe and Wu, Yue and Yin, Ming and Tang, Shange and Huang, Yangsibo and Jin, Chi and Chen, Xinyun and Zhang, Chiyuan and Wang, Mengdi*
 
+1. **Reasoning LLMs are Wandering Solution Explorers** `arXiv preprint` [[paper]](https://arxiv.org/abs/2505.20296)
+
+   *Lu, Jiahao and Xu, Ziwei and Kankanhalli, Mohan*
+
 1. **The Illusion of Thinking: Understanding the Strengths and Limitations of Reasoning Models via the Lens of Problem Complexity** `arXiv preprint` [[paper]](https://arxiv.org/abs/2506.06941)
 
    *Shojaee, Parshin and Mirzadeh, Iman and Alizadeh, Keivan and Horton, Maxwell and Bengio, Samy and Farajtabar, Mehrdad*


### PR DESCRIPTION
Hi, 

Thanks for putting together this excellent survey/repo - it's been a valuable resource for the community.

I noticed our recent paper wasn't included and I'd love to contribute it via a pull request if you're open to it. The paper is titled **"Reasoning LLMs are Wandering Solution Explorers"**, studying failure modes of reasoning LLMs on computational problems across different levels of complexity (it was actually released one week before Apple's *'The Illusion of Thinking'*). 

If this entry looks good and fits the scope of the repo, I'd be grateful for your review and merge.

Many thanks!
Jiahao